### PR TITLE
Fix for null value error

### DIFF
--- a/ikea-tradfri-rgbw-device.groovy
+++ b/ikea-tradfri-rgbw-device.groovy
@@ -486,7 +486,7 @@ def colorGammaRevert(component) {
     return (component <= 0.0031308) ? 12.92 * component : (1.0 + 0.055) * Math.pow(component, (1.0 / 2.4)) - 0.055;
 }
 
-def colorXy2Rgb(x, y) {
+def colorXy2Rgb(x = 255, y = 255) {
 
     logTrace "< Color xy: ($x, $y)"
 


### PR DESCRIPTION
I encountered an issue where I was getting errors when setting colors due to x sometimes being null. There wasn't anything to catch or avoid the issue, so I set the default values to 255 for both params to avoid this issue in the future. After having done so, I am no longer getting errors in the logs and the bulb is functioning very well.